### PR TITLE
Remove redundant variable definitions

### DIFF
--- a/cube_windows.cpp
+++ b/cube_windows.cpp
@@ -79,7 +79,7 @@ int main(void)
 	group_triangles(cube_vertices, triangles);
 
 	// tests
-	loop(terminal_x, terminal_y, terminal_z, p_cube_vertices, cube_vertices);
+	loop(terminal_x, terminal_y, terminal_z, cube_vertices, cube_vertices);
 	
 	return 0;
 }

--- a/cube_windows.cpp
+++ b/cube_windows.cpp
@@ -140,9 +140,9 @@ void draw_cube_vertices(double *p_cube_vertices[3], int len_to_vertex, int termi
 				if (offset_system[2] == 0)
 				{
 					// 3 * vertex iterates over the number of vertexes in the array (i.e. 3 * 1 -> cube_vertices[1][0])
-					*(p_cube_vertices + (3 * vertex) + j) = centre_x - pythag_len;
+					p_cube_vertices[vertex][j] = centre_x - pythag_len;
 				} else {
-					*(p_cube_vertices + (3 * vertex) + j) = centre_x + pythag_len;
+					p_cube_vertices[vertex][j] = centre_x + pythag_len;
 				}
 	
 
@@ -150,18 +150,18 @@ void draw_cube_vertices(double *p_cube_vertices[3], int len_to_vertex, int termi
 				// y coordinate
 				if (offset_system[1] == 0)
 				{
-					*(p_cube_vertices + (3 * vertex) + j) = centre_y - pythag_len;
+					p_cube_vertices[vertex][j] = centre_y - pythag_len;
 				} else {
-					*(p_cube_vertices + (3 * vertex) + j) = centre_y + pythag_len;
+					p_cube_vertices[vertex][j] = centre_y + pythag_len;
 				}
 
 			} else if (j == 2) {
 				// z coordinate
 				if (offset_system[0] == 0)
 				{
-					*(p_cube_vertices + (3 * vertex) + j) = centre_z - pythag_len;
+					p_cube_vertices[vertex][j] = centre_z - pythag_len;
 				} else {
-					*(p_cube_vertices + (3 * vertex) + j) = centre_z + pythag_len;
+					p_cube_vertices[vertex][j] = centre_z + pythag_len;
 				}
 
 			} else {

--- a/cube_windows.cpp
+++ b/cube_windows.cpp
@@ -30,9 +30,8 @@ int main(void)
 	// set console width & height
 	// p_screen is used as a pointer to store the height and width from a function
 	int screen_size[2];
-	int* p_screen_size = &screen_size[0];
 
-	get_screen_size(p_screen_size);
+	get_screen_size(screen_size);
 
 	int terminal_x = screen_size[0];
 	int terminal_y = screen_size[1];
@@ -55,9 +54,8 @@ int main(void)
 		}
 	*/
 	double cube_vertices[8][3];
-	double* p_cube_vertices = &cube_vertices[0][0];
 
-	draw_cube_vertices(p_cube_vertices, len_to_vertex, terminal_x, terminal_y, terminal_z);
+	draw_cube_vertices(cube_vertices, len_to_vertex, terminal_x, terminal_y, terminal_z);
 	
 	std::cout << "successfully drew vertexes! \n";
 
@@ -77,9 +75,8 @@ int main(void)
 		notes: we will always have 6 faces (of a cube), 12 triangles, 8 vertices. 3 vertices makes up a triangles.
 	*/
 	double triangles[12][3][3];
-	double* p_triangles = &triangles[0][0][0];
 
-	group_triangles(cube_vertices, p_triangles);
+	group_triangles(cube_vertices, triangles);
 
 	// tests
 	loop(terminal_x, terminal_y, terminal_z, p_cube_vertices, cube_vertices);

--- a/cube_windows.cpp
+++ b/cube_windows.cpp
@@ -18,12 +18,12 @@ const bool rotate_y = true;
 const bool rotate_z = true;
 
 void get_screen_size(int* p_screen);
-void draw_cube_vertices(double* p_cube_vertices, int len_to_vertex, int terminal_x, int terminal_y, int terminal_z);
+void draw_cube_vertices(double* p_cube_vertices[3], int len_to_vertex, int terminal_x, int terminal_y, int terminal_z);
 void test_vertex_render(int terminal_x, int terminal_y, double cube_vertices[8][3]);
 void rotate_vertices(double angle, double cube_vertices[8][3], double* p_cube_vertices, int terminal_x, int terminal_y, int terminal_z);
 void multiply_rotation_matrices(double* matrix, double* coord);
 void loop(int terminal_x, int terminal_y, int terminal_z, double* p_cube_vertices, double cube_vertices[8][3]);
-void group_triangles(double cube_vertices[8][3], double* p_triangles);
+void group_triangles(double *cube_vertices[3], double* p_triangles[3][3]);
 
 int main(void)
 {
@@ -104,7 +104,7 @@ void get_screen_size(int* p_screen)
 }
 
 
-void draw_cube_vertices(double* p_cube_vertices, int len_to_vertex, int terminal_x, int terminal_y, int terminal_z)
+void draw_cube_vertices(double *p_cube_vertices[3], int len_to_vertex, int terminal_x, int terminal_y, int terminal_z)
 {
 	/*
 		I'm using a weird hacky way to draw the vertices - it probably would be better to use some form of matrix multiplication but its done this way:
@@ -443,7 +443,7 @@ void loop(int terminal_x, int terminal_y, int terminal_z, double* p_cube_vertice
   }
 }
 
-void group_triangles(double cube_vertices[8][3], double* p_triangles)
+void group_triangles(double *cube_vertices[3], double *p_triangles[3][3])
 {
 	/*
 		to start grouping triangles, we pick two random vertices. these two vertices cannot exceed the length of pythag_len (shortest length between two vertices)


### PR DESCRIPTION
These arrays are already pointers to their first elements. So we can pass the arrays as pointers, and in fact, we should eliminate extra variables that point to the same memory loc!

Before merging, make sure it compiles and runs on your end. And maybe use a linter to make sure I'm not going crazy here...